### PR TITLE
[ES|QL] Compare query builders using identity

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -154,7 +154,7 @@ public abstract class FullTextFunction extends Function
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), query, queryBuilder);
+        return Objects.hash(super.hashCode(), query, System.identityHashCode(queryBuilder));
     }
 
     @Override
@@ -163,7 +163,9 @@ public abstract class FullTextFunction extends Function
             return false;
         }
 
-        return Objects.equals(queryBuilder, ((FullTextFunction) obj).queryBuilder) && Objects.equals(query, ((FullTextFunction) obj).query);
+        // Compare query builders using identity because that's how they are compared during query rewriting
+        FullTextFunction other = (FullTextFunction) obj;
+        return queryBuilder == other.queryBuilder && Objects.equals(query, other.query);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/SingleFieldFullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/SingleFieldFullTextFunction.java
@@ -195,14 +195,14 @@ public abstract class SingleFieldFullTextFunction extends FullTextFunction
         // We override equals and hashcode to ignore options when comparing two function instances
         if (o == null || getClass() != o.getClass()) return false;
         SingleFieldFullTextFunction that = (SingleFieldFullTextFunction) o;
-        return Objects.equals(field(), that.field())
-            && Objects.equals(query(), that.query())
-            && Objects.equals(queryBuilder(), that.queryBuilder());
+
+        // Compare query builders using identity because that's how they are compared during query rewriting
+        return Objects.equals(field(), that.field()) && Objects.equals(query(), that.query()) && queryBuilder() == that.queryBuilder();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(field(), query(), queryBuilder());
+        return Objects.hash(field(), query(), System.identityHashCode(queryBuilder()));
     }
 
     /**


### PR DESCRIPTION

Updates the full-text functions to compare query builders using identity. This aligns the query builder comparison behavior with Query DSL and Retrievers. It also prevents infinite rewrites on queries that rewrite in ways that preserve equality while generating new instances.